### PR TITLE
Add configurable filesystem disk support for PWA assets

### DIFF
--- a/config/filament-pwa.php
+++ b/config/filament-pwa.php
@@ -13,5 +13,16 @@ return [
      * Allow Routes
      * ---------------------------------------------------------------
      */
-    "allow_routes" => true
+    "allow_routes" => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Upload Disk
+    |--------------------------------------------------------------------------
+    |
+    | Filesystem disk used for PWA icons, splash screens and shortcut icons.
+    |
+    */
+
+    'upload_disk' => env('FILAMENT_PWA_UPLOAD_DISK', 'public'),
 ];

--- a/src/Console/FilamentPwaInstall.php
+++ b/src/Console/FilamentPwaInstall.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use TomatoPHP\ConsoleHelpers\Traits\RunCommand;
 use TomatoPHP\FilamentPWA\Settings\PWASettings;
+use TomatoPHP\FilamentPWA\Support\PwaAsset;
 
 class FilamentPwaInstall extends Command
 {
@@ -64,15 +65,16 @@ class FilamentPwaInstall extends Command
         $getJsWorkerFile = File::exists($jsPath);
         if($getJsWorkerFile){
             $getJsWorkerFile = File::get($jsPath);
-            $icons = [];
-            $setting->pwa_icons_72x72 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_72x72 : "/images/icons/icon-72x72.png";
-            $setting->pwa_icons_96x96 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_96x96 : "/images/icons/icon-96x96.png";
-            $setting->pwa_icons_128x128 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_128x128 : "/images/icons/icon-128x128.png";
-            $setting->pwa_icons_144x144 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_144x144 : "/images/icons/icon-144x144.png";
-            $setting->pwa_icons_152x152 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_152x152 : "/images/icons/icon-152x152.png";
-            $setting->pwa_icons_192x192 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_192x192 : "/images/icons/icon-192x192.png";
-            $setting->pwa_icons_384x384 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_384x384 : "/images/icons/icon-384x384.png";
-            $setting->pwa_icons_512x512 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_512x512 : "/images/icons/icon-512x512.png";
+            $icons = [
+                '    "' . PwaAsset::url($setting->pwa_icons_72x72, "/images/icons/icon-72x72.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_96x96, "/images/icons/icon-96x96.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_128x128, "/images/icons/icon-128x128.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_144x144, "/images/icons/icon-144x144.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_152x152, "/images/icons/icon-152x152.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_192x192, "/images/icons/icon-192x192.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_384x384, "/images/icons/icon-384x384.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_512x512, "/images/icons/icon-512x512.png"),
+            ];
 
             $value = str($getJsWorkerFile)->replace('ICONS', collect($icons)->implode('",'."\n") . '"')->__toString();
 

--- a/src/Filament/Pages/PWASettingsPage.php
+++ b/src/Filament/Pages/PWASettingsPage.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Spatie\Sitemap\SitemapGenerator;
 use TomatoPHP\FilamentPWA\Settings\PWASettings;
+use TomatoPHP\FilamentPWA\Support\PwaAsset;
 use TomatoPHP\FilamentSettingsHub\Settings\SitesSettings;
 use TomatoPHP\FilamentSettingsHub\Traits\UseShield;
 use function Filament\Support\is_app_url;
@@ -54,6 +55,18 @@ class PWASettingsPage extends SettingsPage
                 ->route('filament.'.filament()->getCurrentPanel()->getId().'.pages.settings-hub'))
                 ->color('danger')
                 ->label(trans('filament-settings-hub::messages.back')),
+        ];
+    }
+
+    protected function pwaUpload(): array
+    {
+        $disk = config('filament-pwa.upload_disk');
+
+        return [
+            'disk' => $disk,
+            'visibility' => $disk === 'public'
+                ? 'public'
+                : 'private',
         ];
     }
 
@@ -112,49 +125,57 @@ class PWASettingsPage extends SettingsPage
                     ->schema([
                         FileUpload::make('pwa_icons_72x72')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_icons_72x72'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_icons_72x72")' : null),
                         FileUpload::make('pwa_icons_96x96')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_icons_96x96'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_icons_96x96")' : null),
                         FileUpload::make('pwa_icons_128x128')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_icons_128x128'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_icons_128x128")' : null),
                         FileUpload::make('pwa_icons_144x144')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_icons_144x144'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_icons_144x144")' : null),
                         FileUpload::make('pwa_icons_152x152')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_icons_152x152'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_icons_152x152")' : null),
                         FileUpload::make('pwa_icons_192x192')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_icons_192x192'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_icons_192x192")' : null),
                         FileUpload::make('pwa_icons_384x384')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_icons_384x384'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_icons_384x384")' : null),
                         FileUpload::make('pwa_icons_512x512')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_icons_512x512'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_icons_512x512")' : null),
@@ -165,61 +186,71 @@ class PWASettingsPage extends SettingsPage
                     ->schema([
                         FileUpload::make('pwa_splash_640x1136')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_640x1136'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_640x1136")' : null),
                         FileUpload::make('pwa_splash_750x1334')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_750x1334'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_750x1334")' : null),
                         FileUpload::make('pwa_splash_828x1792')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_828x1792'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_828x1792")' : null),
                         FileUpload::make('pwa_splash_1125x2436')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_1125x2436'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_1125x2436")' : null),
                         FileUpload::make('pwa_splash_1242x2208')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_1242x2208'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_1242x2208")' : null),
                         FileUpload::make('pwa_splash_1242x2688')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_1242x2688'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_1242x2688")' : null),
                         FileUpload::make('pwa_splash_1536x2048')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_1536x2048'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_1536x2048")' : null),
                         FileUpload::make('pwa_splash_1668x2224')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_1668x2224'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_1668x2224")' : null),
                         FileUpload::make('pwa_splash_1668x2388')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_1668x2388'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_1668x2388")' : null),
                         FileUpload::make('pwa_splash_2048x2732')
                             ->acceptedFileTypes(['image/png'])
-                            ->visibility('public')
+                            ->disk($this->pwaUpload()['disk'])
+                            ->visibility($this->pwaUpload()['visibility'])
                             ->label(trans('filament-pwa::messages.form.pwa_splash_2048x2732'))
                             ->columnSpan(2)
                             ->hint(config('filament-settings-hub.show_hint') ? 'setting("pwa_splash_2048x2732")' : null),
@@ -257,15 +288,17 @@ class PWASettingsPage extends SettingsPage
         $getJsWorkerFile = File::exists($jsPath);
         if($getJsWorkerFile){
             $getJsWorkerFile = File::get($jsPath);
-            $icons = [];
-            $setting->pwa_icons_72x72 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_72x72 : "/images/icons/icon-72x72.png";
-            $setting->pwa_icons_96x96 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_96x96 : "/images/icons/icon-96x96.png";
-            $setting->pwa_icons_128x128 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_128x128 : "/images/icons/icon-128x128.png";
-            $setting->pwa_icons_144x144 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_144x144 : "/images/icons/icon-144x144.png";
-            $setting->pwa_icons_152x152 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_152x152 : "/images/icons/icon-152x152.png";
-            $setting->pwa_icons_192x192 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_192x192 : "/images/icons/icon-192x192.png";
-            $setting->pwa_icons_384x384 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_384x384 : "/images/icons/icon-384x384.png";
-            $setting->pwa_icons_512x512 ? $icons[] = '    "'.'/storage/' . $setting->pwa_icons_512x512 : "/images/icons/icon-512x512.png";
+
+            $icons = [
+                '    "' . PwaAsset::url($setting->pwa_icons_72x72, "/images/icons/icon-72x72.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_96x96, "/images/icons/icon-96x96.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_128x128, "/images/icons/icon-128x128.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_144x144, "/images/icons/icon-144x144.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_152x152, "/images/icons/icon-152x152.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_192x192, "/images/icons/icon-192x192.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_384x384, "/images/icons/icon-384x384.png"),
+                '    "' . PwaAsset::url($setting->pwa_icons_512x512, "/images/icons/icon-512x512.png"),
+            ];
 
             $value = str($getJsWorkerFile)->replace('ICONS', collect($icons)->implode('",'."\n") . '"')->__toString();
 

--- a/src/Filament/Pages/PWASettingsPage.php
+++ b/src/Filament/Pages/PWASettingsPage.php
@@ -270,7 +270,8 @@ class PWASettingsPage extends SettingsPage
                                     ->label(trans('filament-pwa::messages.form.pwa_shortcuts_url')),
                                 FileUpload::make('icon')
                                     ->image()
-                                    ->visibility('public')
+                                    ->disk($this->pwaUpload()['disk'])
+                                    ->visibility($this->pwaUpload()['visibility'])
                                     ->label(trans('filament-pwa::messages.form.pwa_shortcuts_icon')),
                             ])
                             ->label(trans('filament-pwa::messages.form.pwa_shortcuts'))

--- a/src/Services/ManifestService.php
+++ b/src/Services/ManifestService.php
@@ -2,12 +2,16 @@
 
 namespace TomatoPHP\FilamentPWA\Services;
 
+use TomatoPHP\FilamentPWA\Support\PwaAsset;
+use TomatoPHP\FilamentPWA\Settings\PWASettings;
+
 class ManifestService
 {
     public static function generate()
     {
-        $setting = new \TomatoPHP\FilamentPWA\Settings\PWASettings();
-        $basicManifest =  [
+        $setting = new PWASettings();
+
+        $basicManifest = [
             'name' => $setting->pwa_app_name,
             'short_name' => $setting->pwa_short_name,
             'start_url' => asset($setting->pwa_start_url),
@@ -15,99 +19,92 @@ class ManifestService
             'theme_color' => $setting->pwa_theme_color,
             'background_color' => $setting->pwa_background_color,
             'orientation' => $setting->pwa_orientation,
-            'status_bar' =>  $setting->pwa_status_bar,
-            'splash' =>  [
-                '640x1136' => $setting->pwa_splash_640x1136 ? '/storage/'.$setting->pwa_splash_640x1136 : "/images/icons/splash-640x1136.png",
-                '750x1334' => $setting->pwa_splash_750x1334 ? '/storage/'.$setting->pwa_splash_750x1334 : "/images/icons/splash-750x1334.png",
-                '828x1792' => $setting->pwa_splash_828x1792 ? '/storage/'.$setting->pwa_splash_828x1792 : "/images/icons/splash-828x1792.png",
-                '1125x2436' => $setting->pwa_splash_1125x2436 ? '/storage/'.$setting->pwa_splash_1125x2436 : "/images/icons/splash-1125x2436.png",
-                '1242x2208' => $setting->pwa_splash_1242x2208 ? '/storage/'.$setting->pwa_splash_1242x2208 : "/images/icons/splash-1242x2208.png",
-                '1242x2688' => $setting->pwa_splash_1242x2688 ? '/storage/'.$setting->pwa_splash_1242x2688 : "/images/icons/splash-1242x2688.png",
-                '1536x2048' => $setting->pwa_splash_1536x2048 ? '/storage/'.$setting->pwa_splash_1536x2048 : "/images/icons/splash-1536x2048.png",
-                '1668x2224' => $setting->pwa_splash_1668x2224 ? '/storage/'.$setting->pwa_splash_1668x2224 : "/images/icons/splash-1668x2224.png",
-                '1668x2388' => $setting->pwa_splash_1668x2388 ? '/storage/'.$setting->pwa_splash_1668x2388 : "/images/icons/splash-1668x2388.png",
-                '2048x2732' => $setting->pwa_splash_2048x2732 ? '/storage/'.$setting->pwa_splash_2048x2732 : "/images/icons/splash-2048x2732.png",
+            'status_bar' => $setting->pwa_status_bar,
+
+            'splash' => [
+                '640x1136' => PwaAsset::url($setting->pwa_splash_640x1136, '/images/icons/splash-640x1136.png'),
+                '750x1334' => PwaAsset::url($setting->pwa_splash_750x1334, '/images/icons/splash-750x1334.png'),
+                '828x1792' => PwaAsset::url($setting->pwa_splash_828x1792, '/images/icons/splash-828x1792.png'),
+                '1125x2436'=> PwaAsset::url($setting->pwa_splash_1125x2436, '/images/icons/splash-1125x2436.png'),
+                '1242x2208'=> PwaAsset::url($setting->pwa_splash_1242x2208, '/images/icons/splash-1242x2208.png'),
+                '1242x2688'=> PwaAsset::url($setting->pwa_splash_1242x2688, '/images/icons/splash-1242x2688.png'),
+                '1536x2048'=> PwaAsset::url($setting->pwa_splash_1536x2048, '/images/icons/splash-1536x2048.png'),
+                '1668x2224'=> PwaAsset::url($setting->pwa_splash_1668x2224, '/images/icons/splash-1668x2224.png'),
+                '1668x2388'=> PwaAsset::url($setting->pwa_splash_1668x2388, '/images/icons/splash-1668x2388.png'),
+                '2048x2732'=> PwaAsset::url($setting->pwa_splash_2048x2732, '/images/icons/splash-2048x2732.png'),
             ],
+
             'icons' => [
                 [
-                    'src' => $setting->pwa_icons_72x72 ? '/storage/'.$setting->pwa_icons_72x72 : "/images/icons/icon-72x72.png",
-                    'type' => 'image/png',
-                    'sizes' => "72x72",
+                    'src' => PwaAsset::url($setting->pwa_icons_72x72, '/images/icons/icon-72x72.png'),
+                    'type' => PwaAsset::mime($setting->pwa_icons_72x72),
+                    'sizes' => '72x72',
                     'purpose' => 'any'
                 ],
                 [
-                    'src' => $setting->pwa_icons_96x96 ? '/storage/'.$setting->pwa_icons_96x96 : "/images/icons/icon-96x96.png",
-                    'type' => 'image/png',
-                    'sizes' => "96x96",
+                    'src' => PwaAsset::url($setting->pwa_icons_96x96, '/images/icons/icon-96x96.png'),
+                    'type' => PwaAsset::mime($setting->pwa_icons_96x96),
+                    'sizes' => '96x96',
                     'purpose' => 'any'
                 ],
                 [
-                    'src' => $setting->pwa_icons_128x128 ? '/storage/'.$setting->pwa_icons_128x128 : "/images/icons/icon-128x128.png",
-                    'type' => 'image/png',
-                    'sizes' => "128x128",
+                    'src' => PwaAsset::url($setting->pwa_icons_128x128, '/images/icons/icon-128x128.png'),
+                    'type' => PwaAsset::mime($setting->pwa_icons_128x128),
+                    'sizes' => '128x128',
                     'purpose' => 'any'
                 ],
                 [
-                    'src' => $setting->pwa_icons_144x144 ? '/storage/'.$setting->pwa_icons_144x144 : "/images/icons/icon-144x144.png",
-                    'type' => 'image/png',
-                    'sizes' => "144x144",
+                    'src' => PwaAsset::url($setting->pwa_icons_144x144, '/images/icons/icon-144x144.png'),
+                    'type' => PwaAsset::mime($setting->pwa_icons_144x144),
+                    'sizes' => '144x144',
                     'purpose' => 'any'
                 ],
                 [
-                    'src' => $setting->pwa_icons_152x152 ? '/storage/'.$setting->pwa_icons_152x152 : "/images/icons/icon-152x152.png",
-                    'type' => 'image/png',
-                    'sizes' => "152x152",
+                    'src' => PwaAsset::url($setting->pwa_icons_152x152, '/images/icons/icon-152x152.png'),
+                    'type' => PwaAsset::mime($setting->pwa_icons_152x152),
+                    'sizes' => '152x152',
                     'purpose' => 'any'
                 ],
                 [
-                    'src' => $setting->pwa_icons_192x192 ? '/storage/'.$setting->pwa_icons_192x192 : "/images/icons/icon-192x192.png",
-                    'type' => 'image/png',
-                    'sizes' => "192x192",
+                    'src' => PwaAsset::url($setting->pwa_icons_192x192, '/images/icons/icon-192x192.png'),
+                    'type' => PwaAsset::mime($setting->pwa_icons_192x192),
+                    'sizes' => '192x192',
                     'purpose' => 'any'
                 ],
                 [
-                    'src' => $setting->pwa_icons_384x384 ? '/storage/'.$setting->pwa_icons_384x384 : "/images/icons/icon-384x384.png",
-                    'type' => 'image/png',
-                    'sizes' => "384x384",
+                    'src' => PwaAsset::url($setting->pwa_icons_384x384, '/images/icons/icon-384x384.png'),
+                    'type' => PwaAsset::mime($setting->pwa_icons_384x384),
+                    'sizes' => '384x384',
                     'purpose' => 'any'
                 ],
                 [
-                    'src' => $setting->pwa_icons_512x512 ? '/storage/'.$setting->pwa_icons_512x512 : "/images/icons/icon-512x512.png",
-                    'type' => 'image/png',
-                    'sizes' => "512x512",
+                    'src' => PwaAsset::url($setting->pwa_icons_512x512, '/images/icons/icon-512x512.png'),
+                    'type' => PwaAsset::mime($setting->pwa_icons_512x512),
+                    'sizes' => '512x512',
                     'purpose' => 'any'
                 ],
             ]
         ];
 
-        foreach ($basicManifest['icons'] as $key=>$icon){
-            $fileInfo = pathinfo(storage_path('app/public/' .$icon['src']));
-            $basicManifest['icons'][$key]['type'] = 'image/' . $fileInfo['extension'];
-        }
-
-
         if ($setting->pwa_shortcuts) {
             foreach ($setting->pwa_shortcuts as $shortcut) {
 
-                if (array_key_exists("icon", $shortcut)) {
-                    $fileInfo = pathinfo(storage_path('app/public/' . $shortcut['icon']));
+                $icon=[];
+
+                if(array_key_exists('icon',$shortcut)) {
                     $icon = [
-                        'src' => $shortcut['icon'],
-                        'type' => 'image/' . $fileInfo['extension'],
-                        'sizes' => "72x72",
-                        'purpose' => "any"
+                        'src' => PwaAsset::url($shortcut['icon'],''),
+                        'type' => PwaAsset::mime($shortcut['icon']),
+                        'sizes' => '72x72',
+                        'purpose' => 'any'
                     ];
-                } else {
-                    $icon = [];
                 }
 
                 $basicManifest['shortcuts'][] = [
                     'name' => trans($shortcut['name']),
                     'description' => trans($shortcut['description']),
                     'url' => $shortcut['url'],
-                    'icons' => [
-                        $icon
-                    ]
+                    'icons' => [$icon]
                 ];
             }
         }

--- a/src/Services/ManifestService.php
+++ b/src/Services/ManifestService.php
@@ -89,23 +89,25 @@ class ManifestService
         if ($setting->pwa_shortcuts) {
             foreach ($setting->pwa_shortcuts as $shortcut) {
 
-                $icon=[];
-
-                if(array_key_exists('icon',$shortcut)) {
-                    $icon = [
-                        'src' => PwaAsset::url($shortcut['icon'],''),
-                        'type' => PwaAsset::mime($shortcut['icon']),
-                        'sizes' => '72x72',
-                        'purpose' => 'any'
-                    ];
-                }
-
-                $basicManifest['shortcuts'][] = [
+                $shortcutManifest = [
                     'name' => trans($shortcut['name']),
                     'description' => trans($shortcut['description']),
                     'url' => $shortcut['url'],
-                    'icons' => [$icon]
                 ];
+
+                if (
+                    array_key_exists('icon', $shortcut)
+                    && filled($shortcut['icon'])
+                ) {
+                    $shortcutManifest['icons'] = [[
+                        'src' => PwaAsset::url($shortcut['icon'], ''),
+                        'type' => PwaAsset::mime($shortcut['icon']),
+                        'sizes' => '72x72',
+                        'purpose' => 'any',
+                    ]];
+                }
+
+                $basicManifest['shortcuts'][] = $shortcutManifest;
             }
         }
 

--- a/src/Support/PwaAsset.php
+++ b/src/Support/PwaAsset.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TomatoPHP\FilamentPWA\Support;
+
+use Illuminate\Support\Facades\Storage;
+
+class PwaAsset
+{
+    public static function disk(): string
+    {
+        return config('filament-pwa.upload_disk');
+    }
+
+    public static function url(?string $path, string $fallback): string
+    {
+        if (!$path) {
+            return $fallback;
+        }
+
+        return Storage::disk(static::disk())->url($path);
+    }
+
+    public static function mime(?string $path): string
+    {
+        if (!$path) {
+            return 'image/png';
+        }
+
+        $mime = Storage::disk(static::disk())->mimeType($path);
+
+        return $mime ?: 'image/png';
+    }
+}

--- a/src/Support/PwaAsset.php
+++ b/src/Support/PwaAsset.php
@@ -20,7 +20,7 @@ class PwaAsset
         $disk = static::disk();
 
         if ($disk === 'public') {
-            return ltrim($path, '/');
+            return '/storage/' . ltrim($path, '/');
         }
 
         return Storage::disk($disk)->url($path);
@@ -32,8 +32,12 @@ class PwaAsset
             return 'image/png';
         }
 
-        $mime = Storage::disk(static::disk())->mimeType($path);
-
-        return $mime ?: 'image/png';
+        try {
+            return Storage::disk(static::disk())
+                ->mimeType($path)
+                ?: 'image/png';
+        } catch (\Throwable) {
+            return 'image/png';
+        }
     }
 }

--- a/src/Support/PwaAsset.php
+++ b/src/Support/PwaAsset.php
@@ -17,7 +17,13 @@ class PwaAsset
             return $fallback;
         }
 
-        return Storage::disk(static::disk())->url($path);
+        $disk = static::disk();
+
+        if ($disk === 'public') {
+            return ltrim($path, '/');
+        }
+
+        return Storage::disk($disk)->url($path);
     }
 
     public static function mime(?string $path): string


### PR DESCRIPTION
## Summary

This PR removes hardcoded assumptions that PWA assets are always stored on the `public` disk and adds support for configuring the filesystem disk used for:

- PWA icons
- Splash screens
- Shortcut icons

Assets now use Laravel's Storage APIs for:

- Upload storage (`FileUpload::disk(...)`)
- URL generation
- MIME type detection

This allows using disks such as:

- public (default)
- s3
- any disk supporting `Storage::url()`

For backward compatibility, the `public` disk still generates `/storage/...` asset paths as before.

---

## Migration Notes

A new config option was added in `config/filament-pwa.php`:

```php
'upload_disk' => env('FILAMENT_PWA_UPLOAD_DISK', 'public'),
```

To publish the new parameter, you can use `php artisan vendor:publish --tag=filament-pwa-config --force`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable upload disk setting for PWA assets via environment variable, allowing administrators to customize asset storage location with fallback to public storage

* **Improvements**
  * Centralized icon URL and MIME type resolution system for improved PWA asset reliability and consistency
  * Enhanced PWA asset storage configuration with improved disk management and visibility control for icons and splash screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->